### PR TITLE
Support up to MC 1.21.1 & Update the Build Compiler (Shadow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Command Items [![Support](https://img.shields.io/badge/Minecraft-1.15--1.20.4-green.svg)](https://github.com/Relaxing9/commanditems/releases) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2c1f79c66c514af2895150213ce2a7e9)](https://github.com/Relaxing9/commanditems)
+# Command Items [![Support](https://img.shields.io/badge/Minecraft-1.15--1.21.1-green.svg)](https://github.com/Relaxing9/commanditems/releases) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2c1f79c66c514af2895150213ce2a7e9)](https://github.com/Relaxing9/commanditems)
 <div align="center">
   <img src="https://img.shields.io/github/v/release/Relaxing9/CommandItems?style=for-the-badge" alt="Release"/>
   <img src="https://img.shields.io/github/last-commit/Relaxing9/CommandItems?label=Last%20Updated&style=for-the-badge" alt="Last Updated"/>

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 plugins {
-    id 'io.github.goooler.shadow' version "8.1.8"
+    id 'com.gradleup.shadow' version "8.3.0"
     id 'java'
 }
-    // id 'com.github.johnrengelman.shadow' version "8.1.1"
 
 group 'me.relaxing9.commanditems'
-version '2.6.5'
+version '2.6.6'
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -28,7 +27,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.17.2"
 
-    implementation "de.tr7zw:item-nbt-api:2.13.1"
+    implementation "de.tr7zw:item-nbt-api:2.13.2"
 }
 
 shadowJar {

--- a/src/main/java/me/relaxing9/commanditems/CommandItems.java
+++ b/src/main/java/me/relaxing9/commanditems/CommandItems.java
@@ -30,7 +30,7 @@ public class CommandItems extends JavaPlugin {
     public void onEnable() {
         new Metrics(this, 1002);
 
-        boolean debug = System.getProperty("me.yamakaja.debug") != null;
+        boolean debug = System.getProperty("me.relaxing9.debug") != null;
         this.saveResource("config.yml", debug);
         this.saveResource("messages.yml", debug);
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: CommandItems
 authors: [Yamakaja, Relaxing9]
 main: me.relaxing9.commanditems.CommandItems
-version: "2.6.5"
+version: "2.6.6"
 api-version: "1.15"
 api: []
 


### PR DESCRIPTION
* Change the compiler of shadow, this in turn also heavily reduces jar size (new maintainer)
* Bump CommandItems version
* Bump NBT-API dependency for MC 1.21.1 support
* Update supported versions on README
* Change the System key property for debug